### PR TITLE
fix: only file to file mount is valid indocker compose

### DIFF
--- a/volumes/docker-compose.yaml
+++ b/volumes/docker-compose.yaml
@@ -110,7 +110,7 @@ services:
     networks:
       - elastic
     volumes:
-      - ./kibana.yml/:/usr/share/kibana/config/kibana.yml:ro
+      - ./kibana.yml:/usr/share/kibana/config/kibana.yml:ro
     depends_on: 
       - elasticsearch
 


### PR DESCRIPTION
Docker-compose supports only file to file mount and not folder to file mount, and the initial filepath denotes folder to file mount